### PR TITLE
fix: url and description are not optional

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -57,17 +57,20 @@ export const VALIDATORS: Validators = {
       ? true
       : `Must be CamelCase, e.g. "Example"`,
   repo: value =>
-    typeof value !== 'string' || value.trim().length === 0
-      ? true
-      : /^https?:\/\//.test(value)
-      ? true
-      : `Must be a URL, e.g. "https://github.com/<user>/<repo>"`,
+    typeof value !== 'string' ||
+    value.trim().length === 0 ||
+    !/^https?:\/\//.test(value)
+      ? `Must be a URL, e.g. "https://github.com/<user>/<repo>"`
+      : true,
   author: () => true,
   license: value =>
     typeof value !== 'string' || value.trim().length === 0
       ? `Must provide a valid license, e.g. "MIT"`
       : true,
-  description: () => true,
+  description: value =>
+    typeof value !== 'string' || value.trim().length === 0
+      ? `Must provide a description`
+      : true,
   dir: value =>
     typeof value !== 'string' || value.trim().length === 0
       ? `Must provide a directory, e.g. "my-plugin"`

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -54,9 +54,7 @@ export const gatherDetails = (
       {
         type: 'text',
         name: 'repo',
-        message: `${kleur.bold(
-          'What is the repository URL for your plugin?',
-        )}\n`,
+        message: `What is the repository URL for your plugin?\n`,
         validate: VALIDATORS.repo,
         format: value => value.trim(),
       },
@@ -89,9 +87,7 @@ export const gatherDetails = (
       {
         type: 'text',
         name: 'description',
-        message: `${kleur.bold(
-          'Enter a short description of plugin features.',
-        )}\n`,
+        message: `Enter a short description of plugin features.\n`,
         validate: VALIDATORS.description,
         format: value => value.trim(),
       },

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -54,7 +54,7 @@ export const gatherDetails = (
       {
         type: 'text',
         name: 'repo',
-        message: `${kleur.reset('(optional)')} ${kleur.bold(
+        message: `${kleur.bold(
           'What is the repository URL for your plugin?',
         )}\n`,
         validate: VALIDATORS.repo,
@@ -89,7 +89,7 @@ export const gatherDetails = (
       {
         type: 'text',
         name: 'description',
-        message: `${kleur.reset('(optional)')} ${kleur.bold(
+        message: `${kleur.bold(
           'Enter a short description of plugin features.',
         )}\n`,
         validate: VALIDATORS.description,


### PR DESCRIPTION
the url and the description are not optional, they are required on the podspec, running `pod lib lint` in the plugin folder will show errors if they are not present in the package.json (since the podspec read the values from there)