### PR TITLE
chore: bump @capacitor/docgen version

### DIFF
--- a/assets/plugin-template/package.json.mustache
+++ b/assets/plugin-template/package.json.mustache
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@capacitor/android": "{{{ CAPACITOR_VERSION }}}",
     "@capacitor/core": "{{{ CAPACITOR_VERSION }}}",
-    "@capacitor/docgen": "^0.0.4",
+    "@capacitor/docgen": "^0.0.6",
     "@capacitor/ios": "{{{ CAPACITOR_VERSION }}}",
     "@ionic/eslint-config": "^0.2.1",
     "@ionic/prettier-config": "^1.0.0",


### PR DESCRIPTION
0.0.6 fix the problem generating docs when build folder is not present. We have `^`, so should be picking it anyway, but on my tests it isn't, so bumping the version on the template to make sure it picks latest.