### PR TITLE
chore: remove plugin registry types

### DIFF
--- a/assets/plugin-template/src/definitions.ts.mustache
+++ b/assets/plugin-template/src/definitions.ts.mustache
@@ -1,9 +1,3 @@
-declare module '@capacitor/core' {
-  interface PluginRegistry {
-    {{ CLASS }}: {{ CLASS }}Plugin;
-  }
-}
-
 export interface {{ CLASS }}Plugin {
   echo(options: { value: string }): Promise<{ value: string }>;
 }


### PR DESCRIPTION
As of 3.0.0-alpha.7, this is no longer needed. The "plugin registry" is deprecated/internal.