### PR TITLE
fix: update docgen to correct plugin types

### DIFF
--- a/assets/plugin-template/package.json.mustache
+++ b/assets/plugin-template/package.json.mustache
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@capacitor/android": "{{{ CAPACITOR_VERSION }}}",
     "@capacitor/core": "{{{ CAPACITOR_VERSION }}}",
-    "@capacitor/docgen": "^0.0.10",
+    "@capacitor/docgen": "^0.0.18",
     "@capacitor/ios": "{{{ CAPACITOR_VERSION }}}",
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "^1.0.1",


### PR DESCRIPTION
0.0.10 has a problem that creates incorrect return types, update to 0.0.18 as it's latest at the moment

closes https://github.com/ionic-team/create-capacitor-plugin/issues/71