### PR TITLE
Extend interface by default

### DIFF
--- a/assets/plugin-template/src/definitions.ts.mustache
+++ b/assets/plugin-template/src/definitions.ts.mustache
@@ -1,3 +1,5 @@
-export interface {{ CLASS }}Plugin {
+import { Plugin } from '@capacitor/core'
+
+export interface {{ CLASS }}Plugin extends Plugin {
   echo(options: { value: string }): Promise<{ value: string }>;
 }


### PR DESCRIPTION
Fixes addListener and any other types inside Plugin interface from "@capacitor/core" being not found inside definitions file.

Related to [this issue](https://forum.ionicframework.com/t/calling-addlistener-in-typescript-to-add-event-listener-to-capacitor-plugin/220224)