### PR TITLE
fix: create example app with latest

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ export const run = async (): Promise<void> => {
   try {
     await runSubprocess(
       'npm',
-      ['init', '@capacitor/app', 'example', '--', '--name', 'example', '--app-id', 'com.example.plugin'],
+      ['init', '@capacitor/app@latest', 'example', '--', '--name', 'example', '--app-id', 'com.example.plugin'],
       opts,
     );
 


### PR DESCRIPTION
it was creating the example app with a cached version, make sure it always uses latest