### PR TITLE
feat: improve the generated sample app

### DIFF
--- a/assets/www-template/index.html
+++ b/assets/www-template/index.html
@@ -21,8 +21,6 @@
       <button onclick="testEcho()">Click Me!</button>
     </main>
 
-    <script src="capacitor.js"></script>
-    <script src="js/plugin.js"></script>
-    <script src="js/example.js"></script>
+    <script src="./js/example.js" type="module"></script>
   </body>
 </html>

--- a/assets/www-template/js/example.js.mustache
+++ b/assets/www-template/js/example.js.mustache
@@ -1,4 +1,6 @@
-const testEcho = () => {
+import { {{ CLASS }} } from '{{ PACKAGE_NAME }}';
+
+window.testEcho = () => {
     const inputValue = document.getElementById("echoInput").value;
-    capacitor{{ CLASS }}.{{ CLASS }}.echo({ value: inputValue })
+    {{ CLASS }}.echo({ value: inputValue })
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,9 +95,11 @@ export const run = async (): Promise<void> => {
     // Use www template
     await extractTemplate(wwwDir, details, 'WWW_TEMPLATE');
 
-    // Copy over built plugin and capacitor runtime
-    const builtPluginFile = resolve(details.dir, 'dist', 'plugin.js');
-    copyFileSync(builtPluginFile, resolve(wwwDir, 'js', 'plugin.js'));
+    await runSubprocess('npm', ['run', 'build'], {
+      cwd: resolve(opts.cwd, 'example'),
+      stdio: opts.stdio,
+    });
+    
     await runSubprocess('npx', ['cap', 'copy'], {
       cwd: resolve(opts.cwd, 'example'),
       stdio: opts.stdio,


### PR DESCRIPTION
Use the plugin from the package instead of copying the plugin file to the src folder to benefit from the sample app that uses vite.