### PR TITLE
fix: install tslib

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "kleur": "^4.1.5",
     "mustache": "^4.2.0",
     "prompts": "^2.4.2",
-    "tar": "^6.1.11"
+    "tar": "^6.1.11",
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@ionic/eslint-config": "^0.3.0",


### PR DESCRIPTION
looks like tslib is needed for some reason once the library is published