### PR TITLE
feat: rename example app folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can also try the following methods to use this package:
 
 ### Example Apps
 
-As of the `0.8.0` release, example apps for testing are included when initializing a new plugin. To use these templates, you can open the `npx cap open android` or `npx cap open ios` command for Android and iOS respectively. Anything in the `example` folder will be excluded when publishing to npm.
+As of the `0.8.0` release, example apps for testing are included when initializing a new plugin. To use these templates, you can open the `npx cap open android` or `npx cap open ios` command for Android and iOS respectively. Anything in the `example-app` folder will be excluded when publishing to npm.
 
 ### Options
 

--- a/assets/plugin-template/.eslintignore
+++ b/assets/plugin-template/.eslintignore
@@ -1,3 +1,3 @@
 build
 dist
-example
+example-app

--- a/assets/plugin-template/.prettierignore
+++ b/assets/plugin-template/.prettierignore
@@ -1,3 +1,3 @@
 build
 dist
-example
+example-app

--- a/assets/www-template/index.html
+++ b/assets/www-template/index.html
@@ -13,7 +13,7 @@
     <main>
       <h1>Capacitor Test Plugin Project</h1>
       <p>
-        This project can be used to test out the functionality of your plugin. Nothing in the <em>example/</em> folder
+        This project can be used to test out the functionality of your plugin. Nothing in the <em>example-app/</em> folder
         will be published to npm when using this template, so you can create away!
       </p>
       <label for="echoInput">Echo Text:</label>

--- a/assets/www-template/index.html
+++ b/assets/www-template/index.html
@@ -13,8 +13,8 @@
     <main>
       <h1>Capacitor Test Plugin Project</h1>
       <p>
-        This project can be used to test out the functionality of your plugin. Nothing in the <em>example-app/</em> folder
-        will be published to npm when using this template, so you can create away!
+        This project can be used to test out the functionality of your plugin. Nothing in the
+        <em>example-app/</em> folder will be published to npm when using this template, so you can create away!
       </p>
       <label for="echoInput">Echo Text:</label>
       <input type="text" id="echoInput" name="echoInput" value="Hello World!" />

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,52 +69,52 @@ export const run = async (): Promise<void> => {
   try {
     await runSubprocess(
       'npm',
-      ['init', '@capacitor/app@latest', 'example', '--', '--name', 'example', '--app-id', 'com.example.plugin'],
+      ['init', '@capacitor/app@latest', 'example-app', '--', '--name', 'example-app', '--app-id', 'com.example.plugin'],
       opts,
     );
 
     // Add newly created plugin to example app
-    const appPackageJsonStr = readFileSync(resolve(details.dir, 'example', 'package.json'), 'utf8');
+    const appPackageJsonStr = readFileSync(resolve(details.dir, 'example-app', 'package.json'), 'utf8');
     const appPackageJsonObj = JSON.parse(appPackageJsonStr);
     appPackageJsonObj.dependencies[details.name] = 'file:..';
     appPackageJsonObj.dependencies['@capacitor/ios'] = CAPACITOR_VERSION;
     appPackageJsonObj.dependencies['@capacitor/android'] = CAPACITOR_VERSION;
 
-    writeFileSync(resolve(details.dir, 'example', 'package.json'), JSON.stringify(appPackageJsonObj, null, 2));
+    writeFileSync(resolve(details.dir, 'example-app', 'package.json'), JSON.stringify(appPackageJsonObj, null, 2));
 
     // Install packages and add ios and android apps
-    await runSubprocess('npm', ['install', '--no-package-lock', '--prefix', 'example'], opts);
+    await runSubprocess('npm', ['install', '--no-package-lock', '--prefix', 'example-app'], opts);
 
-    // Build newly created plugin and move into the example folder
+    // Build newly created plugin and move into the example-app folder
     await runSubprocess('npm', ['run', 'build'], opts);
 
-    // remove existing web example
-    const wwwDir = resolve(dir, 'example', 'src');
+    // remove existing web example-app
+    const wwwDir = resolve(dir, 'example-app', 'src');
     rmSync(resolve(wwwDir), { recursive: true, force: true });
 
     // Use www template
     await extractTemplate(wwwDir, details, 'WWW_TEMPLATE');
 
     await runSubprocess('npm', ['run', 'build'], {
-      cwd: resolve(opts.cwd, 'example'),
+      cwd: resolve(opts.cwd, 'example-app'),
       stdio: opts.stdio,
     });
 
     await runSubprocess('npx', ['cap', 'copy'], {
-      cwd: resolve(opts.cwd, 'example'),
+      cwd: resolve(opts.cwd, 'example-app'),
       stdio: opts.stdio,
     });
 
     // Add iOS
     await runSubprocess('npx', ['cap', 'add', 'ios'], {
       ...opts,
-      cwd: resolve(details.dir, 'example'),
+      cwd: resolve(details.dir, 'example-app'),
     });
 
     // Add Android
     await runSubprocess('npx', ['cap', 'add', 'android'], {
       ...opts,
-      cwd: resolve(details.dir, 'example'),
+      cwd: resolve(details.dir, 'example-app'),
     });
   } catch (e: any) {
     process.stderr.write(`WARN: Could not create test application: ${e.message ?? e.stack ?? e}\n`);


### PR DESCRIPTION
New capacitor plugins are calling the example app `example-app` instead of just `example`, so changing it to match.

Also prevents problems with lint/prettier if the user didn't change the default names since `example` in ignore files was causing any example folder to be ignored, with the rename that shouldn't happen.