### PR TITLE
fix: don't escape package names with scope

### DIFF
--- a/assets/www-template/js/example.js.mustache
+++ b/assets/www-template/js/example.js.mustache
@@ -1,4 +1,4 @@
-import { {{ CLASS }} } from '{{ PACKAGE_NAME }}';
+import { {{ CLASS }} } from '{{{ PACKAGE_NAME }}}';
 
 window.testEcho = () => {
     const inputValue = document.getElementById("echoInput").value;


### PR DESCRIPTION
If the package name has a `/` is being escaped, using three `{}` instead of two fixes it.