### PR TITLE
(feat) Add option to choose between Kotlin or Java for Android plugin development

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,5 @@ As of the `0.8.0` release, example apps for testing are included when initializi
 --author <author> ......... Author name and email (e.g. "Name <name@example.com>")
 --license <id> ............ SPDX License ID (e.g. "MIT")
 --description <text> ...... Short description of plugin features
+--android-lang ............ Language for Android plugin development (e.g. "kotlin" or "java")
 ```

--- a/assets/plugin-template/README.md.mustache
+++ b/assets/plugin-template/README.md.mustache
@@ -4,8 +4,21 @@
 
 ## Install
 
+To use npm
+
 ```bash
 npm install {{{ PACKAGE_NAME }}}
+````
+
+To use yarn
+
+```bash
+yarn add {{{ PACKAGE_NAME }}}
+```
+
+Sync native files
+
+```bash
 npx cap sync
 ```
 

--- a/assets/plugin-template/android/build.gradle.mustache
+++ b/assets/plugin-template/android/build.gradle.mustache
@@ -3,26 +3,38 @@ ext {
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.7.0'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.2.1'
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.6.1'
+{{ #IS_KOTLIN }}
+    androidxCoreKTXVersion = project.hasProperty('androidxCoreKTXVersion') ? rootProject.ext.androidxCoreKTXVersion : '1.15.0'
+{{ /IS_KOTLIN }}
 }
 
 buildscript {
+{{ #IS_KOTLIN }}
+    ext.kotlin_version = project.hasProperty("kotlin_version") ? rootProject.ext.kotlin_version : '1.9.25'
+{{ /IS_KOTLIN }}
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.2'
+        classpath 'com.android.tools.build:gradle:8.7.3'
+{{ #IS_KOTLIN }}
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+{{ /IS_KOTLIN }}
     }
 }
 
 apply plugin: 'com.android.library'
+{{ #IS_KOTLIN }}
+apply plugin: 'kotlin-android'
+{{ /IS_KOTLIN }}
 
 android {
     namespace "{{ PACKAGE_ID }}"
-    compileSdk project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 35
+    compileSdk project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion as Integer : 35
     defaultConfig {
-        minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 23
-        targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 35
+        minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion as Integer : 23
+        targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion as Integer : 35
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -52,6 +64,9 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
+{{ #IS_KOTLIN }}
+    implementation "androidx.core:core-ktx:$androidxCoreKTXVersion"
+{{ /IS_KOTLIN }}
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"

--- a/assets/plugin-template/android/src/main/kotlin/__JAVA_PATH__.kt.mustache
+++ b/assets/plugin-template/android/src/main/kotlin/__JAVA_PATH__.kt.mustache
@@ -1,0 +1,11 @@
+package {{ PACKAGE_ID }}
+
+import android.util.Log
+
+class {{ CLASS }} {
+
+    fun echo(value: String?): String? {
+        Log.i("Echo", value ?: "null")
+        return value
+    }
+}

--- a/assets/plugin-template/android/src/main/kotlin/__JAVA_PATH__Plugin.kt.mustache
+++ b/assets/plugin-template/android/src/main/kotlin/__JAVA_PATH__Plugin.kt.mustache
@@ -1,0 +1,22 @@
+package {{ PACKAGE_ID }}
+
+import com.getcapacitor.JSObject
+import com.getcapacitor.Plugin
+import com.getcapacitor.PluginCall
+import com.getcapacitor.annotation.CapacitorPlugin
+import com.getcapacitor.PluginMethod
+
+@CapacitorPlugin(name = "{{ CLASS }}")
+class {{ CLASS }}Plugin : Plugin() {
+
+    private val implementation = {{ CLASS }}()
+
+    @PluginMethod
+    fun echo(call: PluginCall) {
+        val value = call.getString("value")
+        val ret = JSObject().apply {
+            put("value", implementation.echo(value))
+        }
+        call.resolve(ret)
+    }
+}

--- a/src/help.ts
+++ b/src/help.ts
@@ -10,6 +10,7 @@ const help = `
     --author <author> ......... Author name and email (e.g. "Name <name@example.com>")
     --license <id> ............ SPDX License ID (e.g. "MIT")
     --description <text> ...... Short description of plugin features
+    --android-lang ............ Language for Android plugin development (e.g. "kotlin" or "java")
 
     -h, --help ................ Print help, then quit
     --verbose ................. Print verbose output to stderr

--- a/src/options.ts
+++ b/src/options.ts
@@ -17,6 +17,7 @@ export interface OptionValues {
   author: string;
   license: string;
   description: string;
+  'android-lang': string;
 }
 
 export type Validators = {
@@ -25,7 +26,7 @@ export type Validators = {
 
 const CLI_ARGS = ['dir'] as const;
 
-const CLI_OPTIONS = ['name', 'package-id', 'class-name', 'repo', 'author', 'license', 'description'] as const;
+const CLI_OPTIONS = ['name', 'package-id', 'class-name', 'repo', 'author', 'license', 'description', 'android-lang'] as const;
 
 export const VALIDATORS: Validators = {
   name: (value) =>
@@ -57,6 +58,8 @@ export const VALIDATORS: Validators = {
     typeof value !== 'string' || value.trim().length === 0 ? `Must provide a valid license, e.g. "MIT"` : true,
   description: (value) =>
     typeof value !== 'string' || value.trim().length === 0 ? `Must provide a description` : true,
+  'android-lang': (value) =>
+    typeof value !== 'string' || value.trim().length === 0 ? `Must provide a language, e.g. "kotlin"` : true,
   dir: (value) =>
     typeof value !== 'string' || value.trim().length === 0
       ? `Must provide a directory, e.g. "my-plugin"`

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -82,6 +82,15 @@ export const gatherDetails = (initialOptions: Options): Promise<OptionValues> =>
         validate: VALIDATORS.license,
       },
       {
+        type: 'select',
+        name: 'android-lang',
+        message: `What language would you like to use for your Android plugin?\n`,
+        choices: [
+          { title: 'Kotlin', value: 'kotlin' },
+          { title: 'Java', value: 'java' }
+        ]
+      },
+      {
         type: 'text',
         name: 'description',
         message: `Enter a short description of plugin features.\n`,

--- a/src/template.ts
+++ b/src/template.ts
@@ -1,4 +1,4 @@
-import { readFile, rmdir, mkdir, writeFile, unlink } from 'fs/promises';
+import { readFile, mkdir, writeFile, unlink, readdir, rm } from 'fs/promises';
 import Mustache from 'mustache';
 import { dirname, join, resolve, sep } from 'path';
 import tar from 'tar';
@@ -25,14 +25,22 @@ export const extractTemplate = async (
 ): Promise<void> => {
   const templateFiles: string[] = [];
   const templateFolders: string[] = [];
+  const androidLang = details['android-lang'].toLowerCase();
+
+  // Ensure the target directory exists
   await mkdir(dir, { recursive: true });
+
+  // Extract the template tarball based on the type (PLUGIN_TEMPLATE or WWW_TEMPLATE)
   await tar.extract({
     file: type === 'PLUGIN_TEMPLATE' ? TEMPLATE_PATH : WWW_TEMPLATE_PATH,
     cwd: dir,
     filter: (p) => {
+      // Collect template files and folders, applying filters as needed
       if (p.endsWith(MUSTACHE_EXTENSION)) {
         templateFiles.push(p);
       }
+
+      // Add plugin folders to the list for further processing
       if (p.endsWith('__CLASS__Plugin/') || p.endsWith('__CLASS__PluginTests/')) {
         templateFolders.push(p);
       }
@@ -41,14 +49,45 @@ export const extractTemplate = async (
   });
 
   await Promise.all(templateFiles.map((p) => resolve(dir, p)).map((p) => applyTemplate(p, details)));
-  await Promise.all(templateFolders.map((p) => resolve(dir, p)).map((p) => rmdir(p)));
+
+  await deleteUnnecessaryFolders(dir, androidLang);
+
+  await Promise.all(templateFolders.map((p) => resolve(dir, p)).map((p) => rm(p, { recursive: true })));
+};
+
+const deleteUnnecessaryFolders = async (dir: string, androidLang: string): Promise<void> => {
+  const androidFolder = join(dir, 'android', 'src', 'main');
+  const javaFolder = join(androidFolder, 'java');
+  const kotlinFolder = join(androidFolder, 'kotlin');
+
+  if (androidLang === 'kotlin' && await folderExists(javaFolder)) {
+    await rm(javaFolder, { recursive: true });
+  }
+
+  if (androidLang === 'java' && await folderExists(kotlinFolder)) {
+    await rm(kotlinFolder, { recursive: true });
+  }
+};
+
+const folderExists = async (folderPath: string): Promise<boolean> => {
+  try {
+    const files = await readdir(folderPath);
+    return files != null;
+  } catch (err) {
+    return false;
+  }
 };
 
 export const applyTemplate = async (
   p: string,
-  { name, 'package-id': packageId, 'class-name': className, repo, author, license, description }: OptionValues,
+  { name, 'package-id': packageId, 'class-name': className, repo, author, license, description, 'android-lang': androidLang }: OptionValues,
 ): Promise<void> => {
   const template = await readFile(p, { encoding: 'utf8' });
+
+  const conditionalView = {
+    KOTLIN: androidLang.toLowerCase() === 'kotlin'
+  }
+
   const view = {
     CAPACITOR_VERSION: CAPACITOR_VERSION,
     PACKAGE_NAME: name,
@@ -60,17 +99,28 @@ export const applyTemplate = async (
     AUTHOR: author,
     LICENSE: license,
     DESCRIPTION: description,
+    ANDROID_LANG: androidLang,
   };
 
-  const contents = Mustache.render(template, view);
-  const filePath = Object.entries(view).reduce(
-    (acc, [key, value]) => (value ? acc.replaceAll(`__${key}__`, value) : acc),
-    p.substring(0, p.length - MUSTACHE_EXTENSION.length),
+  // Combine the conditional view with the main view to replace the Mustache variables
+  const combinedView = { ...view, ...conditionalView };
+
+  // First render with all variables
+  const intermediateContents = Mustache.render(template, combinedView);
+
+  // Second render (optional) for further refinement if needed
+  const finalContents = Mustache.render(intermediateContents, view);
+
+  // Generate the file path by replacing Mustache placeholders with actual values
+  let filePath = p.substring(0, p.length - MUSTACHE_EXTENSION.length);
+  filePath = Object.entries(view).reduce(
+    (acc, [key, value]) => (value ? acc.replaceAll(`__${key}__`, value.toString()) : acc),
+    filePath,
   );
 
   await mkdir(dirname(filePath), { recursive: true });
   // take off the .mustache extension and write the file, then remove the template
-  await writeFile(filePath, contents, { encoding: 'utf8' });
+  await writeFile(filePath, finalContents, { encoding: 'utf8' });
 
   await unlink(p);
 };


### PR DESCRIPTION
This pull request introduces the ability to select the programming language (Kotlin or Java) for Android plugin development. This provides flexibility for developers who prefer one language over the other or need to maintain consistency with an existing codebase.