### PR TITLE
SplashScreen.hide() after app loads

### DIFF
--- a/assets/www-template/js/example.js.mustache
+++ b/assets/www-template/js/example.js.mustache
@@ -1,4 +1,9 @@
 import { {{ CLASS }} } from '{{{ PACKAGE_NAME }}}';
+import { SplashScreen } from '@capacitor/splash-screen';
+
+window.onload = () => {
+    SplashScreen.hide()
+}
 
 window.testEcho = () => {
     const inputValue = document.getElementById("echoInput").value;


### PR DESCRIPTION
Since the splash screen plugin is added by default with capacitor, and the default value for "launchAutoHide" is set to false, when building the example app for IOS the splash screen will stay forever. This hides the splash screen when the window loads so the app does not get stuck.