### PR TITLE
fix: make 'android-lang' optional, with java as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,5 @@ As of the `0.8.0` release, example apps for testing are included when initializi
 --author <author> ......... Author name and email (e.g. "Name <name@example.com>")
 --license <id> ............ SPDX License ID (e.g. "MIT")
 --description <text> ...... Short description of plugin features
---android-lang <text> ..... Language for Android plugin development (either "kotlin" or "java")
+--android-lang <text> ..... Language for Android plugin development (either "kotlin" or "java", default is "java")
 ```

--- a/src/help.ts
+++ b/src/help.ts
@@ -10,7 +10,7 @@ const help = `
     --author <author> ......... Author name and email (e.g. "Name <name@example.com>")
     --license <id> ............ SPDX License ID (e.g. "MIT")
     --description <text> ...... Short description of plugin features
-    --android-lang ............ Language for Android plugin development (either "kotlin" or "java")
+    --android-lang ............ Language for Android plugin development (either "kotlin" or "java", default is "java")
 
     -h, --help ................ Print help, then quit
     --verbose ................. Print verbose output to stderr

--- a/src/options.ts
+++ b/src/options.ts
@@ -68,7 +68,7 @@ export const VALIDATORS: Validators = {
   description: (value) =>
     typeof value !== 'string' || value.trim().length === 0 ? `Must provide a description` : true,
   'android-lang': (value) =>
-    value === undefined || value === '' || (typeof value === 'string' && /^(kotlin|kt|java)$/i.test(value))
+    value === undefined || value === '' || (typeof value === 'string' && /^(kotlin|java)$/i.test(value))
       ? true
       : `Must be either "kotlin" or "java"`,
   dir: (value) =>

--- a/src/options.ts
+++ b/src/options.ts
@@ -99,6 +99,12 @@ export const getOptions = (): Options => {
 
     if (typeof validatorResult === 'string') {
       debug(`invalid option: --%s %O: %s`, option, value, validatorResult);
+
+      // 'android-lang' is not prompted, so it should fail if invalid
+      if (option === 'android-lang' && value !== undefined && value !== '') {
+        process.stderr.write(`ERR: Invalid --android-lang value "${value}": ${validatorResult} (should be "kotlin" or "java")\n`);
+        process.exit(1);
+      }
     }
 
     opts[option] = validatorResult === true ? value : undefined;

--- a/src/options.ts
+++ b/src/options.ts
@@ -102,7 +102,9 @@ export const getOptions = (): Options => {
 
       // 'android-lang' is not prompted, so it should fail if invalid
       if (option === 'android-lang' && value !== undefined && value !== '') {
-        process.stderr.write(`ERR: Invalid --android-lang value "${value}": ${validatorResult} (should be "kotlin" or "java")\n`);
+        process.stderr.write(
+          `ERR: Invalid --android-lang value "${value}": ${validatorResult} (should be "kotlin" or "java")\n`,
+        );
         process.exit(1);
       }
     }

--- a/src/options.ts
+++ b/src/options.ts
@@ -17,7 +17,7 @@ export interface OptionValues {
   author: string;
   license: string;
   description: string;
-  'android-lang': string;
+  'android-lang'?: string;
 }
 
 export type Validators = {
@@ -68,7 +68,7 @@ export const VALIDATORS: Validators = {
   description: (value) =>
     typeof value !== 'string' || value.trim().length === 0 ? `Must provide a description` : true,
   'android-lang': (value) =>
-    typeof value === 'string' && value.trim().length > 0 && /^(kotlin|kt|java)$/i.test(value)
+    value === undefined || value === '' || (typeof value === 'string' && /^(kotlin|kt|java)$/i.test(value))
       ? true
       : `Must be either "kotlin" or "java"`,
   dir: (value) =>
@@ -106,5 +106,12 @@ export const getOptions = (): Options => {
     return opts;
   }, {} as Options);
 
-  return { ...argValues, ...optionValues };
+  const allOptions = { ...argValues, ...optionValues };
+
+  // Set default for android-lang if not provided
+  if (!allOptions['android-lang']) {
+    allOptions['android-lang'] = 'java';
+  }
+
+  return allOptions;
 };

--- a/src/options.ts
+++ b/src/options.ts
@@ -114,8 +114,11 @@ export const getOptions = (): Options => {
 
   const allOptions = { ...argValues, ...optionValues };
 
-  // Set default for android-lang if not provided
-  if (!allOptions['android-lang']) {
+  // Normalize and set default for android-lang
+  if (allOptions['android-lang']) {
+    const normalized = allOptions['android-lang'].toLowerCase();
+    allOptions['android-lang'] = normalized === 'kt' ? 'kotlin' : normalized;
+  } else {
     allOptions['android-lang'] = 'java';
   }
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -17,7 +17,7 @@ export interface OptionValues {
   author: string;
   license: string;
   description: string;
-  'android-lang'?: string;
+  'android-lang': string;
 }
 
 export type Validators = {
@@ -101,10 +101,8 @@ export const getOptions = (): Options => {
       debug(`invalid option: --%s %O: %s`, option, value, validatorResult);
 
       // 'android-lang' is not prompted, so it should fail if invalid
-      if (option === 'android-lang' && value !== undefined && value !== '') {
-        process.stderr.write(
-          `ERR: Invalid --android-lang value "${value}": ${validatorResult} (should be "kotlin" or "java")\n`,
-        );
+      if (option === 'android-lang') {
+        process.stderr.write(`ERR: Invalid --android-lang value "${value}": ${validatorResult}\n`);
         process.exit(1);
       }
     }

--- a/src/options.ts
+++ b/src/options.ts
@@ -116,11 +116,7 @@ export const getOptions = (): Options => {
 
   const allOptions = { ...argValues, ...optionValues };
 
-  // Normalize and set default for android-lang
-  if (allOptions['android-lang']) {
-    const normalized = allOptions['android-lang'].toLowerCase();
-    allOptions['android-lang'] = normalized === 'kt' ? 'kotlin' : normalized;
-  } else {
+  if (!allOptions['android-lang']) {
     allOptions['android-lang'] = 'java';
   }
 

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -95,8 +95,11 @@ export const gatherDetails = (initialOptions: Options): Promise<OptionValues> =>
         process.exit(1);
       },
     },
-  ).then(result => ({
-    ...result,
-    'android-lang': initialOptions['android-lang'],
-  } as OptionValues));
+  ).then(
+    (result) =>
+      ({
+        ...result,
+        'android-lang': initialOptions['android-lang'],
+      }) as OptionValues,
+  );
 };

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -82,15 +82,6 @@ export const gatherDetails = (initialOptions: Options): Promise<OptionValues> =>
         validate: VALIDATORS.license,
       },
       {
-        type: 'select',
-        name: 'android-lang',
-        message: `What language would you like to use for your Android plugin?\n`,
-        choices: [
-          { title: 'Kotlin', value: 'kotlin' },
-          { title: 'Java', value: 'java' },
-        ],
-      },
-      {
         type: 'text',
         name: 'description',
         message: `Enter a short description of plugin features.\n`,
@@ -104,5 +95,8 @@ export const gatherDetails = (initialOptions: Options): Promise<OptionValues> =>
         process.exit(1);
       },
     },
-  );
+  ).then(result => ({
+    ...result,
+    'android-lang': initialOptions['android-lang'],
+  } as OptionValues));
 };

--- a/src/template.ts
+++ b/src/template.ts
@@ -25,7 +25,7 @@ export const extractTemplate = async (
 ): Promise<void> => {
   const templateFiles: string[] = [];
   const templateFolders: string[] = [];
-  const androidLang = (details['android-lang'] || 'java').toLowerCase();
+  const androidLang = details['android-lang'].toLowerCase();
   await mkdir(dir, { recursive: true });
   await extract({
     file: type === 'PLUGIN_TEMPLATE' ? TEMPLATE_PATH : WWW_TEMPLATE_PATH,
@@ -84,7 +84,7 @@ export const applyTemplate = async (
     author,
     license,
     description,
-    'android-lang': androidLang = 'java',
+    'android-lang': androidLang,
   }: OptionValues,
 ): Promise<void> => {
   const template = await readFile(p, { encoding: 'utf8' });

--- a/src/template.ts
+++ b/src/template.ts
@@ -25,7 +25,7 @@ export const extractTemplate = async (
 ): Promise<void> => {
   const templateFiles: string[] = [];
   const templateFolders: string[] = [];
-  const androidLang = details['android-lang'].toLowerCase();
+  const androidLang = (details['android-lang'] || 'java').toLowerCase();
   await mkdir(dir, { recursive: true });
   await extract({
     file: type === 'PLUGIN_TEMPLATE' ? TEMPLATE_PATH : WWW_TEMPLATE_PATH,
@@ -84,7 +84,7 @@ export const applyTemplate = async (
     author,
     license,
     description,
-    'android-lang': androidLang,
+    'android-lang': androidLang = 'java',
   }: OptionValues,
 ): Promise<void> => {
   const template = await readFile(p, { encoding: 'utf8' });


### PR DESCRIPTION
## Description

This PR updates the recently added 'android-lang' to be optional, and never be prompted. The default (if no 'android-lang' is provided) was made to be Java. If users want kotlin, they'll have to explicitly set the argument when running the command.

This could be considered a breaking change, but since we're in 0.x version numbers, we're more lenient with breaking changes.

Also fixed a minor bug where when using 'kt' for 'android-lang', the java source directory was not getting removed.

## Change Type
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation

## Rationale / Problems Fixed

We had released a version where Android Language was always prompted, and the option selected by default was kotlin. Some time after the team had some internal discussions, and decided that we should stick to Java, since it is the Android Language that Capacitor framework is built on, and we may switch the default to Kotlin in the future whenever we migrate Capacitor to use Kotlin.

Having a default made it less relevant for the Android Language option to be prompted, so we removed it in order to have one less prompt option for the command. The plan will be as well to update the capacitor-docs to better let users know of this option, improving discoverability.

## Tests or Reproductions

If you want, you may pull the branch, build it, and run it with different 'android-lang' values (and also with no value), and see that you are never prompted for the Android Language

## Platforms Affected
- [x] Android
- [ ] iOS
- [ ] Web

